### PR TITLE
Fix ListVPCs method for AWI Domain Connector

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ RUN mkdir -p /root/go/src/github.com/awi-grpc-catalyst-sdwan
 WORKDIR /root/go/src/github.com/awi-grpc-catalyst-sdwan
 COPY . .
 
+RUN apk add make
+
 RUN make build
 
 # Second stage: create the runtime image

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -246,7 +246,7 @@ func (m *Manager) addRequest(ctx context.Context, reqType requestType, data inte
 }
 
 func (m *Manager) ListSites(ctx context.Context) (*awiGrpc.ListSiteResponse, error) {
-	if !m.isConnectionControllerVManage() {
+	if !m.IsConnectionControllerVManage() {
 		return &awiGrpc.ListSiteResponse{}, nil
 	}
 	sites, err := m.client.Site().List(ctx)
@@ -259,7 +259,7 @@ func (m *Manager) ListSites(ctx context.Context) (*awiGrpc.ListSiteResponse, err
 }
 
 func (m *Manager) ListVPCs(ctx context.Context, request *awiGrpc.ListVPCRequest) (*awiGrpc.ListVPCResponse, error) {
-	if !m.isConnectionControllerVManage() {
+	if !m.IsConnectionControllerVManage() {
 		return &awiGrpc.ListVPCResponse{}, nil
 	}
 	var vpcs = make([]*vpc.VPC, 0)
@@ -291,7 +291,7 @@ func (m *Manager) GetMatchedResources(ctx context.Context, appConnection *awiGrp
 }
 
 func (m *Manager) ListVPCTags(ctx context.Context, request *awiGrpc.ListVPCTagRequest) (*awiGrpc.ListVPCResponse, error) {
-	if !m.isConnectionControllerVManage() {
+	if !m.IsConnectionControllerVManage() {
 		return &awiGrpc.ListVPCResponse{}, nil
 	}
 	params := &vpc.ListVPCTagParameters{
@@ -309,7 +309,7 @@ func (m *Manager) ListVPCTags(ctx context.Context, request *awiGrpc.ListVPCTagRe
 }
 
 func (m *Manager) ListVPNs(ctx context.Context, request *awiGrpc.ListVPNRequest) (*awiGrpc.ListVPNResponse, error) {
-	if !m.isConnectionControllerVManage() {
+	if !m.IsConnectionControllerVManage() {
 		return &awiGrpc.ListVPNResponse{}, nil
 	}
 	vpns, err := m.client.VPN().List(ctx, request.Provider)
@@ -321,7 +321,7 @@ func (m *Manager) ListVPNs(ctx context.Context, request *awiGrpc.ListVPNRequest)
 	}, nil
 }
 
-func (m *Manager) isConnectionControllerVManage() bool {
+func (m *Manager) IsConnectionControllerVManage() bool {
 	return m.connManager.GetConnectorType() == connection_controller.VManageConnector
 }
 

--- a/pkg/translator/translator.go
+++ b/pkg/translator/translator.go
@@ -44,6 +44,21 @@ func ComputeInstancesToAwiGrpcInstances(instances []types.Instance) []*awi.Insta
 	return awiInstances
 }
 
+func ComputeVPCsToAwiGrpcVPCs(vpcs []types.VPC) []*awi.VPC {
+	awiVPCs := make([]*awi.VPC, 0, len(vpcs))
+	for _, vpc := range vpcs {
+		awiVPCs = append(awiVPCs, &awi.VPC{
+			ID:          vpc.ID,
+			Name:        vpc.Name,
+			Region:      vpc.Region,
+			Provider:    vpc.Provider,
+			Labels:      vpc.Labels,
+			AccountName: vpc.AccountID,
+		})
+	}
+	return awiVPCs
+}
+
 func ComputeSubnetsToAwiGrpcSubnets(subnets []types.Subnet) []*awi.Subnet {
 	awiSubnets := make([]*awi.Subnet, 0, len(subnets))
 	for _, subnet := range subnets {


### PR DESCRIPTION
Awi-CLI and Awi-UI use awi-infra-guard codebase for listing most resources including VPCs. However, kube-awi uses older API from awi-grpc-catalyst-sdwan rather than awi-infra-guard.

Currently, most of methods from awi-grpc-catalyst-sdwan are forwarded to awi-infra-guard anyway, but ListVPCs is not and it was implemented to return empty list of VPCs if the connector was not VManage.

This change fixes it by using awi-infra-guard if the connector is different than VManage.